### PR TITLE
rtmp-services: Update SermonAudio entry (#2324)

### DIFF
--- a/plugins/rtmp-services/data/package.json
+++ b/plugins/rtmp-services/data/package.json
@@ -1,10 +1,10 @@
 {
 	"url": "https://obsproject.com/obs2_update/rtmp-services",
-	"version": 120,
+	"version": 121,
 	"files": [
 		{
 			"name": "services.json",
-			"version": 120
+			"version": 121
 		}
 	]
 }

--- a/plugins/rtmp-services/data/services.json
+++ b/plugins/rtmp-services/data/services.json
@@ -1327,16 +1327,19 @@
             }
         },
         {
-            "name": "SermonAudio.com",
+            "name": "SermonAudio Cloud",
+            "alt_names": [
+                "SermonAudio.com"
+            ],
             "servers": [
                 {
                     "name": "Primary",
-                    "url": "rtmp://stream.sermonaudio.com/"
+                    "url": "rtmp://webcast.sermonaudio.com/sa"
                 }
             ],
             "recommended": {
-                "max video bitrate": 1000,
-                "max audio bitrate": 64
+                "max video bitrate": 2000,
+                "max audio bitrate": 128
             }
         },
         {


### PR DESCRIPTION
We have a new back-end to the SermonAudio webcasting system which required a new URL and now allows for increased bitrates.

Added the "alt_names" to avoid breaking backwards compatibility and ensure that users receive the new ingest URLs.