### PR TITLE
UI: Fix closing OBS before showing whats new dialog

### DIFF
--- a/UI/win-update/win-update.cpp
+++ b/UI/win-update/win-update.cpp
@@ -20,7 +20,14 @@
 #include <winhttp.h>
 #include <shellapi.h>
 
+#ifdef BROWSER_AVAILABLE
+#include <browser-panel.hpp>
+#endif
+
 using namespace std;
+
+struct QCef;
+extern QCef *cef;
 
 /* ------------------------------------------------------------------------ */
 
@@ -798,4 +805,14 @@ try {
 
 } catch (string &text) {
 	blog(LOG_WARNING, "%s: %s", __FUNCTION__, text.c_str());
+}
+
+/* ------------------------------------------------------------------------ */
+
+void WhatsNewBrowserInitThread::run()
+{
+#ifdef BROWSER_AVAILABLE
+	cef->wait_for_browser_init();
+#endif
+	emit Result(url);
 }

--- a/UI/win-update/win-update.hpp
+++ b/UI/win-update/win-update.hpp
@@ -33,3 +33,17 @@ signals:
 public:
 	inline WhatsNewInfoThread() {}
 };
+
+class WhatsNewBrowserInitThread : public QThread {
+	Q_OBJECT
+
+	QString url;
+
+	virtual void run() override;
+
+signals:
+	void Result(const QString &url);
+
+public:
+	inline WhatsNewBrowserInitThread(const QString &url_) : url(url_) {}
+};

--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -193,6 +193,8 @@ private:
 	const char *copyFiltersString = nullptr;
 	bool copyVisible = true;
 
+	bool closing = false;
+	QScopedPointer<QThread> whatsNewInitThread;
 	QScopedPointer<QThread> updateCheckThread;
 	QScopedPointer<QThread> introCheckThread;
 	QScopedPointer<QThread> logUploadThread;
@@ -463,6 +465,7 @@ private:
 	void LoadSavedProjectors(obs_data_array_t *savedProjectors);
 
 	void ReceivedIntroJson(const QString &text);
+	void ShowWhatsNew(const QString &url);
 
 #ifdef BROWSER_AVAILABLE
 	QList<QSharedPointer<QDockWidget>> extraBrowserDocks;


### PR DESCRIPTION
The program can get stuck waiting for the browser within a event queue,
so instead mark that the program is closing, do it in a separate thread,
signal the window when it's finished, and then check whether it's in the
process of closing before actually showing the dialog.