### PR TITLE
CI: use a KDE image for Flatpak

### DIFF
--- a/.github/workflows/flatpak.yml
+++ b/.github/workflows/flatpak.yml
@@ -13,7 +13,7 @@ jobs:
     name: Bundle
     runs-on: [ubuntu-latest]
     container:
-      image: docker.io/bilelmoussaoui/flatpak-github-actions
+      image: bilelmoussaoui/flatpak-github-actions:kde-5.15
       options: --privileged
     steps:
     - name: 'Check for Github Labels'


### PR DESCRIPTION
The KDE images comes with the SDK needed pre-installed and should avoid re-downloading/installing it everytime. This should hopefully reduce the build time by a few minutes 

Details at https://github.com/bilelmoussaoui/flatpak-github-actions#docker-image